### PR TITLE
Update README.md; Rename selectors and add new one. Add remove method in ViewStateActionService

### DIFF
--- a/projects/ngx-view-state/CHANGELOG.md
+++ b/projects/ngx-view-state/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## Changelog
 
+## 3.0.0
+
+General changes:
+- Update README.md
+- Rename and new properties,methods,functions
+
+
+- `createViewStateFeature`:
+  - Rename:
+    -  `viewStatesFeatureKey` to `viewStatesFeatureName`
+    -  `selectActionStatus` to `selectActionViewStatus`
+    -  `selectLoadingActions` to `selectIsAnyActionLoading`
+    - `selectViewStateIds` to `selectViewStateActionTypes`
+  - New:
+    - `selectIsAnyActionError`
+    - `selectIsAnyActionLoaded`
+    - `selectIsAnyActionIdle`
+
+
+- `ViewStateActionService`
+  - New:
+    - `remove` method
+
 ## 2.1.0
 
 - fix: If the same action was included in multiple `ViewStateActionsConfig` configs, only last action config would be used. The store, effects and service now correctly handles multiple actions across different configs.

--- a/projects/ngx-view-state/package.json
+++ b/projects/ngx-view-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-view-state",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "ngx-view-state is a library for managing the Loading/Success/Error states of views in Angular applications that use Ngrx or HttpClient",
   "author": "Yurii Khomitskyi <yura.khomitsky8@gmail.com>",

--- a/projects/ngx-view-state/src/lib/view-state/models/view-state-props.model.ts
+++ b/projects/ngx-view-state/src/lib/view-state/models/view-state-props.model.ts
@@ -1,3 +1,6 @@
+/*
+  An interface to implement in Error State component to receive the error object
+ */
 export interface ViewStateErrorProps<E = unknown> {
   viewStateError?: E;
 }

--- a/projects/ngx-view-state/src/lib/view-state/services/view-state-actions.service.spec.ts
+++ b/projects/ngx-view-state/src/lib/view-state/services/view-state-actions.service.spec.ts
@@ -41,19 +41,19 @@ describe('ViewStateActionsService', () => {
 	});
 
 	it('should contain correct actions', () => {
-		expect(service.actionsMap.get(loadData.type)).toEqual([{ viewState: 'startLoading' }]);
-		expect(service.actionsMap.get(loadDataSuccess.type)).toEqual([{ viewState: 'reset', actionType: loadData.type }]);
-		expect(service.actionsMap.get(lodDataFailure.type)).toEqual([{ viewState: 'error', actionType: loadData.type }]);
+		expect(service.getActionConfigs(loadData)).toEqual([{ viewState: 'startLoading' }]);
+		expect(service.getActionConfigs(loadDataSuccess)).toEqual([{ viewState: 'reset', actionType: loadData.type }]);
+		expect(service.getActionConfigs(lodDataFailure)).toEqual([{ viewState: 'error', actionType: loadData.type }]);
 
-		expect(service.actionsMap.get(loadData2.type))
+		expect(service.getActionConfigs(loadData2))
 			.toEqual(jasmine.arrayContaining(
 					[
 						{ viewState: 'startLoading' }, { viewState: 'reset', actionType: loadData.type }
 					]
 				)
 			);
-		expect(service.actionsMap.get(loadDataSuccess2.type)).toEqual([{ viewState: 'reset', actionType: loadData2.type }]);
-		expect(service.actionsMap.get(lodDataFailure2.type))
+		expect(service.getActionConfigs(loadDataSuccess2)).toEqual([{ viewState: 'reset', actionType: loadData2.type }]);
+		expect(service.getActionConfigs(lodDataFailure2))
 			.toEqual(jasmine.arrayContaining(
 					[
 						{ viewState: 'error', actionType: loadData2.type }, { viewState: 'error', actionType: loadData.type }
@@ -61,6 +61,20 @@ describe('ViewStateActionsService', () => {
 				)
 			);
 	});
+
+	describe('remove', () => {
+		it('should remove config for an action', () => {
+			service.remove(loadData);
+
+			expect(service.isViewStateAction(loadData)).toBe(false);
+		});
+
+		it('should remove config for an action from other configs', () => {
+			service.remove(loadData);
+
+			expect(service.getActionConfigs(loadData2)).toEqual([{ viewState: 'startLoading' }]);
+		})
+	})
 
 	describe('isStartLoadingAction', () => {
 		it('should return true for loadData action', () => {

--- a/projects/ngx-view-state/src/lib/view-state/services/view-state-actions.service.ts
+++ b/projects/ngx-view-state/src/lib/view-state/services/view-state-actions.service.ts
@@ -15,7 +15,7 @@ export interface ViewStateActionsConfig {
   providedIn: 'root',
 })
 export class ViewStateActionsService {
-  public readonly actionsMap = new Map<string, ActionsMapConfig[]>();
+  private readonly actionsMap = new Map<string, ActionsMapConfig[]>();
 
   public isViewStateAction(action: Action): boolean {
     return this.actionsMap.has(action.type);
@@ -70,6 +70,17 @@ export class ViewStateActionsService {
       action.errorOn.forEach((errorAction: Action) => {
         this.addActionToMap(errorAction.type, { viewState: 'error', actionType: action.startLoadingOn.type });
       });
+    });
+  }
+
+  public remove(action: Action): void {
+    this.actionsMap.delete(action.type);
+
+    this.actionsMap.forEach((configs: ActionsMapConfig[], key ) => {
+      const filteredConfigs = configs.filter((config: ActionsMapConfig) => {
+        return config.viewState === 'startLoading' || config.actionType !== action.type;
+      });
+      this.actionsMap.set(key, filteredConfigs);
     });
   }
 

--- a/projects/ngx-view-state/src/lib/view-state/store/view-state.selectors.spec.ts
+++ b/projects/ngx-view-state/src/lib/view-state/store/view-state.selectors.spec.ts
@@ -1,13 +1,14 @@
 import { Dictionary } from '@ngrx/entity';
 import { Action } from '@ngrx/store';
 
-import { idleViewStatus, loadingViewStatus } from '../factories';
+import { errorViewStatus, idleViewStatus, loadedViewStatus, loadingViewStatus } from '../factories';
 
 import { createViewStateFeature, ViewState } from './view-state.feature';
 
 describe('ViewStateSelectors', () => {
-  const { selectLoadingActions, selectActionStatus } = createViewStateFeature<string>();
-  describe('selectActionStatus', () => {
+  const { selectIsAnyActionLoading, selectIsAnyActionLoaded, selectIsAnyActionError, selectIsAnyActionIdle, selectActionViewStatus } = createViewStateFeature<string>();
+
+  describe('selectActionViewStatus', () => {
     it('should select action status', () => {
       const action: Action = {
         type: 'update',
@@ -20,7 +21,7 @@ describe('ViewStateSelectors', () => {
         },
       };
 
-      const selector = selectActionStatus(action);
+      const selector = selectActionViewStatus(action);
 
       expect(selector.projector(stateDictionary)).toEqual(loadingViewStatus());
     });
@@ -32,13 +33,13 @@ describe('ViewStateSelectors', () => {
 
       const dataStatuses: Dictionary<ViewState<string>> = {};
 
-      const selector = selectActionStatus(action);
+      const selector = selectActionViewStatus(action);
 
       expect(selector.projector(dataStatuses)).toEqual(idleViewStatus());
     });
   });
 
-  describe('selectLoadingActions', () => {
+  describe('selectIsAnyActionsLoading', () => {
     it('should return true', () => {
       const getDataAction: Action = {
         type: 'get data',
@@ -55,7 +56,7 @@ describe('ViewStateSelectors', () => {
         },
       };
 
-      const selector = selectLoadingActions(getDataAction, getAdditionalDataAction);
+      const selector = selectIsAnyActionLoading(getDataAction, getAdditionalDataAction);
 
       expect(selector.projector(stateDictionary)).toEqual(true);
     });
@@ -71,9 +72,126 @@ describe('ViewStateSelectors', () => {
 
       const stateDictionary: Dictionary<ViewState<string>> = {};
 
-      const selector = selectLoadingActions(getDataAction, getAdditionalDataAction);
+      const selector = selectIsAnyActionLoading(getDataAction, getAdditionalDataAction);
 
       expect(selector.projector(stateDictionary)).toEqual(false);
     });
   });
+
+  describe('selectIsAnyActionsLoaded', () => {
+    it('should return true', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {
+        [getAdditionalDataAction.type]: {
+          actionType: getAdditionalDataAction.type,
+          viewStatus: loadedViewStatus(),
+        },
+      };
+
+      const selector = selectIsAnyActionLoaded(getDataAction, getAdditionalDataAction);
+
+      expect(selector.projector(stateDictionary)).toEqual(true);
+    });
+
+    it('should return false', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {};
+
+      const selector = selectIsAnyActionLoaded(getDataAction, getAdditionalDataAction);
+
+      expect(selector.projector(stateDictionary)).toEqual(false);
+    });
+  })
+
+  describe('selectIsAnyActionsError', () => {
+    it('should return true', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {
+        [getAdditionalDataAction.type]: {
+          actionType: getAdditionalDataAction.type,
+          viewStatus: errorViewStatus('Oops!'),
+        },
+      };
+
+      const selector = selectIsAnyActionError(getDataAction, getAdditionalDataAction);
+
+      expect(selector.projector(stateDictionary)).toEqual(true);
+    });
+
+    it('should return false', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {};
+
+      const selector = selectIsAnyActionError(getDataAction, getAdditionalDataAction);
+
+      expect(selector.projector(stateDictionary)).toEqual(false);
+    });
+  })
+
+  describe('selectIsAnyActionsIdle', () => {
+    it('should return true', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {
+        [getAdditionalDataAction.type]:  {
+          actionType: getAdditionalDataAction.type,
+          viewStatus: idleViewStatus(),
+        }
+      };
+
+      const selector = selectIsAnyActionIdle(getDataAction, getAdditionalDataAction);
+
+      expect(selector.projector(stateDictionary)).toEqual(true);
+    });
+
+    it('should return false', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {};
+
+      const selector = selectIsAnyActionIdle(getDataAction, getAdditionalDataAction);
+
+      expect(selector.projector(stateDictionary)).toEqual(false);
+    });
+  })
 });

--- a/src/app/store/view-state.feature.ts
+++ b/src/app/store/view-state.feature.ts
@@ -1,4 +1,4 @@
 import { createViewStateFeature } from 'ngx-view-state';
 
 
-export const { viewStatesFeature, selectActionStatus, selectLoadingActions } = createViewStateFeature<string>()
+export const { viewStatesFeature, selectActionViewStatus, selectIsAnyActionLoading } = createViewStateFeature<string>()

--- a/src/app/todos/store/todos.selectors.ts
+++ b/src/app/todos/store/todos.selectors.ts
@@ -1,5 +1,5 @@
-import { selectActionStatus, selectLoadingActions } from '../../store/view-state.feature';
+import { selectActionViewStatus, selectIsAnyActionLoading } from '../../store/view-state.feature';
 import { TodosActions } from './todos.actions';
 
-export const selectTodosViewState = selectActionStatus(TodosActions.loadTodos);
-export const selectActionsLoading = selectLoadingActions(TodosActions.addTodo, TodosActions.updateTodo, TodosActions.deleteTodo);
+export const selectTodosViewStatus = selectActionViewStatus(TodosActions.loadTodos);
+export const selectActionsLoading = selectIsAnyActionLoading(TodosActions.addTodo, TodosActions.updateTodo, TodosActions.deleteTodo);

--- a/src/app/todos/todos.component.ts
+++ b/src/app/todos/todos.component.ts
@@ -12,7 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButton } from '@angular/material/button';
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
-import { selectTodosViewState, selectActionsLoading } from './store/todos.selectors';
+import { selectTodosViewStatus, selectActionsLoading } from './store/todos.selectors';
 import { LoadingComponent } from './components/loading/loading.component';
 
 @Component({
@@ -25,7 +25,7 @@ import { LoadingComponent } from './components/loading/loading.component';
 export class TodosComponent {
 	public displayedColumns: (keyof Todo | 'delete')[] = ['id', 'title', 'completed', 'delete'];
 	public todos$ = this.store.select(selectTodos);
-	public viewStatus$ = this.store.select(selectTodosViewState);
+	public viewStatus$ = this.store.select(selectTodosViewStatus);
 	public isOverlayLoading$ = this.store.select(selectActionsLoading);
 	public title = '';
 


### PR DESCRIPTION
Update README.md; Rename selectors and add new one. Add remove method in ViewStateActionService

## 3.0.0

General changes:
- Update README.md
- Rename and new properties,methods,functions


- `createViewStateFeature`:
  - Rename:
    -  `viewStatesFeatureKey` to `viewStatesFeatureName`
    -  `selectActionStatus` to `selectActionViewStatus`
    -  `selectLoadingActions` to `selectIsAnyActionLoading`
    - `selectViewStateIds` to `selectViewStateActionTypes`
  - New:
    - `selectIsAnyActionError`
    - `selectIsAnyActionLoaded`
    - `selectIsAnyActionIdle`


- `ViewStateActionService`
  - New:
    - `remove` method