### PR TITLE
Create custom memoization for selector to emit only uniq view status …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-<h1 style="text-align: center">NgxViewState</h1>
+<div align="center">
+    <h1>ngx-view-state</h1>
+</div>
 
->Library for managing Loading/Success/Error in Angular applications that use NgRx.
+
+> Library for managing Loading/Success/Error in Angular applications that use NgRx.
 
 
 This repository contains example of using `ngx-view-state` library in Angular application and the library itself.
@@ -15,6 +18,7 @@ Run `npm run build-lib watch` to build the library.
 
 Run `npm run start` for a dev server for the Application. Navigate to `http://localhost:4200/`
 
-#### Stackblitz Example
+#### Demo Stackblitz
+
 [https://stackblitz.com/edit/ngx-view-state](https://stackblitz.com/edit/ngx-view-state)
 

--- a/projects/ngx-view-state/CHANGELOG.md
+++ b/projects/ngx-view-state/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+## 3.2.1
+
+General changes:
+- Add custom memo for `selectActionViewStatus` and `selectViewState` selectors to avoid emitting the same view status multiple times
+- Update README.md
+
 ## 3.0.0
 
 General changes:

--- a/projects/ngx-view-state/README.md
+++ b/projects/ngx-view-state/README.md
@@ -1,13 +1,14 @@
-<h1 style="text-align: center;">NgxViewState</h1>
+<div align="center">
+    <h1>ngx-view-state</h1>
+</div>
 
-The `ngx-view-state` library is designed to simplify managing view states(Loading, Success, Error) of HTTP requests in Angular applications that use NGRX.
+The `ngx-view-state` library is designed to simplify managing Loading/Success/Error states in Angular applications that use NgRx.
 
-This library provides set of utils that allow developers to handle different view states such as loading, error, and loaded states.
 
 ## Overview
 
 * [Installation](#installation)
-* [Usage with Ngrx](#usage-with-ngrx)
+* [Usage with NgRx](#usage-with-ngrx)
 * [Usage ngxViewState directive](#usage-ngxviewstate-directive)
 * [Components customization](#components-customization)
 * [Usage with HttpClient](#usage-with-httpclient)
@@ -23,9 +24,9 @@ This library provides set of utils that allow developers to handle different vie
 Run: `npm install ngx-view-state`
 
 
-## Usage With Ngrx
+## Usage With NgRx
 
-1. Create view state feature and pass generic type for the error state
+#### 1. Create view state feature and pass generic type for the error state
     
 ``` typescript
 // view-state.feature.ts
@@ -37,7 +38,7 @@ export const {
     selectIsAnyActionLoading 
 } = createViewStateFeature<string>()
 ```
-2. Provide the `viewStateFeature` and `ViewStateEffect` in the root
+#### 2. Provide the `viewStateFeature` and `ViewStateEffect` in the root
 
 ``` typescript
 // app.config.ts
@@ -55,7 +56,7 @@ export const appConfig: ApplicationConfig = {
 	]
 };
 ```
-3. Register actions in your effect to mark them as view state actions
+#### 3. Register actions in your effect to mark them as view state actions
 
 ``` typescript
 // todos.effects.ts
@@ -82,7 +83,7 @@ constructor(private actions$: Actions, private viewStateActionsService: ViewStat
     }
 }
 ```
-4. Create view state selectors
+#### 4. Create view state selectors
 
 ``` typescript
 // todos.selectors.ts
@@ -98,7 +99,7 @@ export const selectIsTodosActionLoading = selectIsAnyActionLoading(TodosActions.
 
 ```
 
-5. Make use of previously created selectors and dispatch the load action.
+#### 5. Make use of previously created selectors and dispatch the load action.
     
 ``` typescript
 // todos.component.ts
@@ -264,7 +265,7 @@ Where `E` generic is the type of the error state.
 Returns an object with the following properties:
 - `initialState` - Initial state of the view state feature.
 - `viewStatesFeatureName` - Name of the view state feature.
-- `viewStatesFeature` - Ngrx feature that holds the view state of the actions.
+- `viewStatesFeature` - NgRx feature that holds the view state of the actions.
 
 ### Selectors:
 - `selectViewStateEntities` - returns the view state entities.

--- a/projects/ngx-view-state/package.json
+++ b/projects/ngx-view-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-view-state",
-  "version": "3.0.1",
+  "version": "3.2.1",
   "license": "MIT",
   "description": "ngx-view-state is a library for managing the Loading/Success/Error states of views in Angular applications that use Ngrx or HttpClient",
   "author": "Yurii Khomitskyi <yura.khomitsky8@gmail.com>",

--- a/projects/ngx-view-state/src/lib/view-state/store/view-state.selectors.spec.ts
+++ b/projects/ngx-view-state/src/lib/view-state/store/view-state.selectors.spec.ts
@@ -37,6 +37,35 @@ describe('ViewStateSelectors', () => {
 
       expect(selector.projector(dataStatuses)).toEqual(idleViewStatus());
     });
+
+    it('should return the same view status reference if the type is the same', () => {
+      const action: Action = {
+        type: 'update',
+      };
+
+      const initialViewStatus: ViewState<string> = {
+          actionType: action.type,
+          viewStatus: idleViewStatus(),
+        };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {
+        [action.type]: initialViewStatus
+      };
+
+      const selector = selectActionViewStatus(action);
+
+      const viewStatus = selector.projector(stateDictionary);
+      const viewStatusNewReference = selector.projector({
+        ...stateDictionary,
+        [action.type]: {
+          ...initialViewStatus,
+          viewStatus: idleViewStatus()
+        }
+      });
+
+
+      expect(viewStatusNewReference).toBe(viewStatus);
+    })
   });
 
   describe('selectIsAnyActionsLoading', () => {


### PR DESCRIPTION
- Create custom memoization for the selectors to emit only uniq view statuses.

Previously, the selector for selection view status would also emit when other actions triggered a state update unrelated to the selected view status
