### PR TITLE
Remove dependency on @ngrx/entity and implement custom adapters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@angular/platform-browser-dynamic": "^19.0.5",
         "@angular/router": "^19.0.5",
         "@ngrx/effects": "^19.0.0",
-        "@ngrx/entity": "^19.0.0",
         "@ngrx/operators": "^19.0.0",
         "@ngrx/store": "^19.0.0",
         "@ngrx/store-devtools": "^19.0.0",
@@ -3818,19 +3817,6 @@
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-19.0.0.tgz",
       "integrity": "sha512-McNrbaPoDUlukrVPAckpRYLFSOoHwMQgMaiiNUvIGJuH/S1Wja+0xAT/e7+h+SO6xaFqDiEqj7GiR8lPkIAnVw==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^19.0.0",
-        "@ngrx/store": "19.0.0",
-        "rxjs": "^6.5.3 || ^7.5.0"
-      }
-    },
-    "node_modules/@ngrx/entity": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/entity/-/entity-19.0.0.tgz",
-      "integrity": "sha512-qHMgR46YYm1ysEe2hwwTj5Gq6aAg9AxLLMtnBtsUWG6+UKk9irSCl6EoT7QteUGYImNK6LO1wiwapoNgFMr8dg==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -16571,14 +16557,6 @@
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-19.0.0.tgz",
       "integrity": "sha512-McNrbaPoDUlukrVPAckpRYLFSOoHwMQgMaiiNUvIGJuH/S1Wja+0xAT/e7+h+SO6xaFqDiEqj7GiR8lPkIAnVw==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "@ngrx/entity": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/entity/-/entity-19.0.0.tgz",
-      "integrity": "sha512-qHMgR46YYm1ysEe2hwwTj5Gq6aAg9AxLLMtnBtsUWG6+UKk9irSCl6EoT7QteUGYImNK6LO1wiwapoNgFMr8dg==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@angular/platform-browser-dynamic": "^19.0.5",
     "@angular/router": "^19.0.5",
     "@ngrx/effects": "^19.0.0",
-    "@ngrx/entity": "^19.0.0",
     "@ngrx/operators": "^19.0.0",
     "@ngrx/store": "^19.0.0",
     "@ngrx/store-devtools": "^19.0.0",

--- a/projects/ngx-view-state/CHANGELOG.md
+++ b/projects/ngx-view-state/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+## 4.1.0
+
+General changes:
+- Refactor internal state management to remove dependency on `@ngrx/entity` adapter.
+- Replace entity adapter methods with custom adapter functions (`upsertOne`, `upsertMany`, `removeOne`, `removeMany`).
+- Remove `ids` array from state, relying directly on `entities` dictionary for managing action state.
+- Update tests to reflect removal of `ids` and verify new selectors.
+
+No breaking changes to the public API selectors — backward compatible.
+
 ## 4.0.1
 
 General changes:

--- a/projects/ngx-view-state/package.json
+++ b/projects/ngx-view-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-view-state",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "license": "MIT",
   "description": "ngx-view-state is a library for managing the Loading/Success/Error states of views in Angular applications that use Ngrx or HttpClient",
   "author": "Yurii Khomitskyi <yura.khomitsky8@gmail.com>",
@@ -24,7 +24,6 @@
   "peerDependencies": {
     "@angular/core": ">=18.0.0 <20.0.0",
     "@ngrx/effects": ">=18.0.0 <20.0.0",
-    "@ngrx/entity": ">=18.0.0 <20.0.0",
     "@ngrx/store": ">=18.0.0 <20.0.0",
     "rxjs": "^6.5.3 || ^7.5.0"
   },

--- a/projects/ngx-view-state/src/lib/view-state/store/view-state.adapter.ts
+++ b/projects/ngx-view-state/src/lib/view-state/store/view-state.adapter.ts
@@ -1,0 +1,44 @@
+import { ViewState } from './view-state.feature';
+
+export interface Dictionary<T> {
+	[id: string]: T;
+}
+
+export interface EntityState<T> {
+	entities: Dictionary<T>;
+}
+
+export function upsertOne<E>(entity: ViewState<E>, state: EntityState<ViewState<E>>): EntityState<ViewState<E>> {
+	return {
+		entities: {
+			...state.entities,
+			[entity.actionType]: entity
+		}
+	};
+}
+
+export function upsertMany<E>(entities: ViewState<E>[], state: EntityState<ViewState<E>>): EntityState<ViewState<E>> {
+	const newEntities = { ...state.entities };
+
+	for (const entity of entities) {
+		newEntities[entity.actionType] = entity;
+	}
+
+	return { entities: newEntities };
+}
+
+export function removeOne<E>(id: string, state: EntityState<ViewState<E>>): EntityState<ViewState<E>> {
+	const { [id]: removed, ...rest } = state.entities;
+
+	return { entities: rest };
+}
+
+export function removeMany<E>(ids: string[], state: EntityState<ViewState<E>>): EntityState<ViewState<E>> {
+	const newEntities = { ...state.entities };
+
+	for (const id of ids) {
+		delete newEntities[id];
+	}
+
+	return { entities: newEntities };
+}

--- a/projects/ngx-view-state/src/lib/view-state/store/view-state.feature.spec.ts
+++ b/projects/ngx-view-state/src/lib/view-state/store/view-state.feature.spec.ts
@@ -20,7 +20,6 @@ describe('ViewStateFeature', () => {
           viewStatus: loadingViewStatus(),
         },
       },
-      ids: ['123'],
     });
   });
 
@@ -33,7 +32,6 @@ describe('ViewStateFeature', () => {
             viewStatus: loadingViewStatus(),
           },
         },
-        ids: ['123'],
       },
       ViewStateActions.reset({
         actionType: '123',
@@ -42,7 +40,6 @@ describe('ViewStateFeature', () => {
 
     expect(state).toEqual({
       entities: {},
-      ids: [],
     });
   });
 
@@ -50,7 +47,6 @@ describe('ViewStateFeature', () => {
     const state = viewStatesFeature.reducer(
       {
         entities: {},
-        ids: [],
       },
       ViewStateActions.error({
         actionType: '123',
@@ -65,7 +61,6 @@ describe('ViewStateFeature', () => {
           viewStatus: errorViewStatus('Custom error message'),
         },
       },
-      ids: ['123'],
     });
   });
 
@@ -73,7 +68,6 @@ describe('ViewStateFeature', () => {
     const state = viewStatesFeature.reducer(
       {
         entities: {},
-        ids: [],
       },
       ViewStateActions.errorMany({
         actionTypes: [
@@ -94,7 +88,6 @@ describe('ViewStateFeature', () => {
           viewStatus: errorViewStatus('Custom error message 2'),
         },
       },
-      ids: ['123', '456'],
     });
   });
 
@@ -111,7 +104,6 @@ describe('ViewStateFeature', () => {
             viewStatus: loadingViewStatus(),
           },
         },
-        ids: ['123', '456'],
       },
       ViewStateActions.resetMany({
         actionTypes: ['123', '456'],
@@ -120,7 +112,6 @@ describe('ViewStateFeature', () => {
 
     expect(state).toEqual({
       entities: {},
-      ids: [],
     });
   })
 });

--- a/projects/ngx-view-state/src/lib/view-state/store/view-state.selectors.spec.ts
+++ b/projects/ngx-view-state/src/lib/view-state/store/view-state.selectors.spec.ts
@@ -1,12 +1,12 @@
-import { Dictionary } from '@ngrx/entity';
 import { Action } from '@ngrx/store';
 
 import { errorViewStatus, idleViewStatus, loadedViewStatus, loadingViewStatus } from '../factories';
 
 import { createViewStateFeature, ViewState } from './view-state.feature';
+import { Dictionary } from './view-state.adapter';
 
 describe('ViewStateSelectors', () => {
-  const { selectIsAnyActionLoading, selectIsAnyActionLoaded, selectIsAnyActionError, selectIsAnyActionIdle, selectActionViewStatus } = createViewStateFeature<string>();
+  const { selectIsAnyActionLoading, selectIsAnyActionLoaded, selectIsAnyActionError, selectIsAnyActionIdle, selectActionViewStatus, selectAllViewState, selectViewStateActionTypes } = createViewStateFeature<string>();
 
   describe('selectActionViewStatus', () => {
     it('should select action status', () => {
@@ -222,5 +222,68 @@ describe('ViewStateSelectors', () => {
 
       expect(selector.projector(stateDictionary)).toEqual(false);
     });
+  })
+
+  describe('selectAll', () => {
+    it('should return all actions', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {
+        [getDataAction.type]: {
+          actionType: getDataAction.type,
+          viewStatus: loadingViewStatus(),
+        },
+        [getAdditionalDataAction.type]: {
+          actionType: getAdditionalDataAction.type,
+          viewStatus: loadedViewStatus(),
+        }
+      }
+
+
+      expect(selectAllViewState.projector(stateDictionary)).toEqual([
+        {
+          actionType: getDataAction.type,
+          viewStatus: loadingViewStatus(),
+        },
+        {
+          actionType: getAdditionalDataAction.type,
+          viewStatus: loadedViewStatus(),
+        }
+      ]);
+    })
+  })
+
+  describe('selectViewStateActionTypes', () => {
+    it('should return all actions', () => {
+      const getDataAction: Action = {
+        type: 'get data',
+      };
+
+      const getAdditionalDataAction: Action = {
+        type: 'get additional data',
+      };
+
+      const stateDictionary: Dictionary<ViewState<string>> = {
+        [getDataAction.type]: {
+          actionType: getDataAction.type,
+          viewStatus: loadingViewStatus(),
+        },
+        [getAdditionalDataAction.type]: {
+          actionType: getAdditionalDataAction.type,
+          viewStatus: loadedViewStatus(),
+        }
+      }
+
+      expect(selectViewStateActionTypes.projector(Object.values(stateDictionary))).toEqual([
+        getDataAction.type,
+        getAdditionalDataAction.type
+      ]);
+    })
   })
 });

--- a/projects/ngx-view-state/src/lib/view-state/view-state.directive.spec.ts
+++ b/projects/ngx-view-state/src/lib/view-state/view-state.directive.spec.ts
@@ -26,7 +26,7 @@ describe('ViewStateDirective', () => {
     })
     class TestViewStatusHostComponent {
       private viewStatus$ = signal<ViewStatus | null>(null);
-      public viewStatusSubject$ = new Subject<ViewStatus | null>();
+      public viewStatusSubject$: Subject<ViewStatus | null> = new Subject<ViewStatus | null>();
 
       public get viewStatus(): ViewStatus | null {
         return this.viewStatus$()

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -19,7 +19,7 @@ export const appConfig: ApplicationConfig = {
 	providers: [
 		provideRouter(routes),
 		provideHttpClient(),
-		provideStore({}),
+		provideStore({}, { runtimeChecks: { strictStateImmutability: true, strictActionImmutability: true} }),
 		provideState(viewStatesFeature),
 		provideState(todosFeature),
 		provideEffects(ViewStateEffects, TodosEffects),

--- a/src/app/todos/components/error/error.component.spec.ts
+++ b/src/app/todos/components/error/error.component.spec.ts
@@ -1,23 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ErrorComponent } from './error.component';
+import { provideExperimentalZonelessChangeDetection } from '@angular/core';
 
 describe('ErrorComponent', () => {
-  let component: ErrorComponent;
-  let fixture: ComponentFixture<ErrorComponent>;
+	let component: ErrorComponent;
+	let fixture: ComponentFixture<ErrorComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ErrorComponent],
-    })
-    .compileComponents();
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+				imports: [ErrorComponent],
+				providers: [provideExperimentalZonelessChangeDetection()]
+			})
+			.compileComponents();
 
-    fixture = TestBed.createComponent(ErrorComponent);
-    component = fixture.componentInstance;
-    await fixture.whenStable();
-  });
+		fixture = TestBed.createComponent(ErrorComponent);
+		component = fixture.componentInstance;
+		await fixture.whenStable();
+	});
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
 });

--- a/src/app/todos/components/loading/loading.component.spec.ts
+++ b/src/app/todos/components/loading/loading.component.spec.ts
@@ -1,23 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LoadingComponent } from './loading.component';
+import { provideExperimentalZonelessChangeDetection } from '@angular/core';
 
 describe('LoadingComponent', () => {
-  let component: LoadingComponent;
-  let fixture: ComponentFixture<LoadingComponent>;
+	let component: LoadingComponent;
+	let fixture: ComponentFixture<LoadingComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [LoadingComponent]
-    })
-    .compileComponents();
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+				imports: [LoadingComponent],
+				providers: [provideExperimentalZonelessChangeDetection()]
+			})
+			.compileComponents();
 
-    fixture = TestBed.createComponent(LoadingComponent);
-    component = fixture.componentInstance;
-    await fixture.whenStable();
-  });
+		fixture = TestBed.createComponent(LoadingComponent);
+		component = fixture.componentInstance;
+		await fixture.whenStable();
+	});
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
 });

--- a/src/app/todos/todos.component.spec.ts
+++ b/src/app/todos/todos.component.spec.ts
@@ -1,23 +1,43 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TodosComponent } from './todos.component';
+import { provideExperimentalZonelessChangeDetection } from '@angular/core';
+import { provideMockStore } from '@ngrx/store/testing';
+import { selectTodos } from './store/todos.feature';
+import { selectActionsLoading, selectTodosViewStatus } from './store/todos.selectors';
+import { idleViewStatus } from 'ngx-view-state';
 
 describe('TodosComponent', () => {
-  let component: TodosComponent;
-  let fixture: ComponentFixture<TodosComponent>;
+	let component: TodosComponent;
+	let fixture: ComponentFixture<TodosComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TodosComponent]
-    })
-    .compileComponents();
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+				imports: [TodosComponent],
+				providers: [provideExperimentalZonelessChangeDetection(), provideMockStore({
+					selectors: [{
+						selector: selectTodos,
+						value: []
+					},
+						{
+							selector: selectTodosViewStatus,
+							value: idleViewStatus()
+						},
+						{
+							selector: selectActionsLoading,
+							value: false
+						}
+					]
+				})]
+			})
+			.compileComponents();
 
-    fixture = TestBed.createComponent(TodosComponent);
-    component = fixture.componentInstance;
-    await fixture.whenStable();
-  });
+		fixture = TestBed.createComponent(TodosComponent);
+		component = fixture.componentInstance;
+		await fixture.whenStable();
+	});
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
 });


### PR DESCRIPTION
Replaced @ngrx/entity methods with custom adapter functions for managing entity states to simplify and optimize the codebase. Updated selectors and tests to reflect the new implementation, ensuring backward compatibility for the public API. Removed unused `ids` from state and relied only on the `entities` dictionary.